### PR TITLE
Fix Telugu regex

### DIFF
--- a/fixture/all-telugu-chars.js
+++ b/fixture/all-telugu-chars.js
@@ -1,46 +1,75 @@
-export default function allTeluguChars() {
-	// Using visual code point representation for better human intelligibility
-	const independentVowels = ['అ', 'ఆ', 'ఇ', 'ఈ', 'ఉ', 'ఊ', 'ఋ', 'ౠ', 'ఌ', 'ౡ', 'ఎ', 'ఏ', 'ఐ', 'ఒ', 'ఓ', 'ఔ'];
-	const diacriticVowels = ['ా', 'ి', 'ీ', 'ు', 'ూ', 'ృ', 'ౄ', 'ౢ', 'ౣ', 'ె', 'ే', 'ై', 'ొ', 'ో', 'ౌ'];
-	const consonants = ['క', 'ఖ', 'గ', 'ఘ', 'ఙ', 'చ', 'ఛ', 'జ', 'ఝ', 'ఞ', 'ట', 'ఠ', 'డ', 'ఢ', 'ణ', 'త', 'థ', 'ద', 'ధ', 'న', 'ప', 'ఫ', 'బ', 'భ', 'మ', 'య', 'ర', 'ల', 'వ', 'ళ', 'శ', 'ష', 'స', 'హ', 'ఱ'];
-	const rareConsonants = ['ౘ', 'ౙ', 'ౚ'];
-	const modifiers = ['్', 'ఁ', 'ం', 'ః', 'ౕ', 'ౖ'];
-	const numerals = ['౦', '౧', '౨', '౩', '౪', '౫', '౬', '౭', '౮', '౯', '౸', '౹', '౺', '౻', '౼', '౽', '౾'];
-	const virama = '్';
+// Using visual code point representation for better human intelligibility
+const independentVowels = ['అ', 'ఆ', 'ఇ', 'ఈ', 'ఉ', 'ఊ', 'ఋ', 'ౠ', 'ఌ', 'ౡ', 'ఎ', 'ఏ', 'ఐ', 'ఒ', 'ఓ', 'ఔ'];
+const diacriticVowels = ['ా', 'ి', 'ీ', 'ు', 'ూ', 'ృ', 'ౄ', 'ౢ', 'ౣ', 'ె', 'ే', 'ై', 'ొ', 'ో', 'ౌ'];
+const consonants = ['క', 'ఖ', 'గ', 'ఘ', 'ఙ', 'చ', 'ఛ', 'జ', 'ఝ', 'ఞ', 'ట', 'ఠ', 'డ', 'ఢ', 'ణ', 'త', 'థ', 'ద', 'ధ', 'న', 'ప', 'ఫ', 'బ', 'భ', 'మ', 'య', 'ర', 'ల', 'వ', 'ళ', 'శ', 'ష', 'స', 'హ', 'ఱ'];
+const rareConsonants = ['ౘ', 'ౙ', 'ౚ'];
+const modifiers = ['్', 'ఁ', 'ం', 'ః', 'ౕ', 'ౖ'];
+const numerals = ['౦', '౧', '౨', '౩', '౪', '౫', '౬', '౭', '౮', '౯', '౸', '౹', '౺', '౻', '౼', '౽', '౾'];
+const virama = '్';
 
-	const doubleCombos = []; // Telugu symbols built out of two code points
-	const tripleCombos = []; // Telugu symbols built out of three code points
+const doubleCombos = []; // Telugu symbols built out of two code points
+const tripleCombos = []; // Telugu symbols built out of three code points
 
-	// Consonants can be combined with many other character modifiers
-	for (const consonant of consonants) {
-		// Consonant + vowel
-		for (const vowel of diacriticVowels) {
-			doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), vowel.codePointAt(0)));
-		}
-
-		// Consonant + special vowel modifier or length mark
-		for (const modifier of modifiers) {
-			doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), modifier.codePointAt(0)));
-		}
-
-		// Consonant + consonant (separated by ్)
-		for (const consonant2 of consonants) {
-			tripleCombos.push(String.fromCodePoint(consonant.codePointAt(0), virama.codePointAt(0), consonant2.codePointAt(0)));
-		}
+// Consonants can be combined with many other character modifiers
+for (const consonant of consonants) {
+	// Consonant + vowel
+	for (const vowel of diacriticVowels) {
+		doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), vowel.codePointAt(0)));
 	}
 
-	// Rare consonants like common consonants, but lack the consonant conjuncts
-	for (const consonant of rareConsonants) {
-		// Rare consonant + vowel
-		for (const vowel of diacriticVowels) {
-			doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), vowel.codePointAt(0)));
-		}
-
-		// Rare consonant + special vowel modifier or length mark
-		for (const modifier of modifiers) {
-			doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), modifier.codePointAt(0)));
-		}
+	// Consonant + special vowel modifier or length mark
+	for (const modifier of modifiers) {
+		doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), modifier.codePointAt(0)));
 	}
 
+	// Consonant + consonant (separated by ్)
+	for (const consonant2 of consonants) {
+		tripleCombos.push(String.fromCodePoint(consonant.codePointAt(0), virama.codePointAt(0), consonant2.codePointAt(0)));
+	}
+}
+
+// Rare consonants like common consonants, but lack the consonant conjuncts
+for (const consonant of rareConsonants) {
+	// Rare consonant + vowel
+	for (const vowel of diacriticVowels) {
+		doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), vowel.codePointAt(0)));
+	}
+
+	// Rare consonant + special vowel modifier or length mark
+	for (const modifier of modifiers) {
+		doubleCombos.push(String.fromCodePoint(consonant.codePointAt(0), modifier.codePointAt(0)));
+	}
+}
+
+/**
+ * Create all single Telugu chars possible.
+ * @return {string[]} All single Telugu chars possible.
+ */
+export function createAllTeluguChars() {
 	return [...independentVowels, ...consonants, ...rareConsonants, ...numerals, ...doubleCombos, ...tripleCombos];
+}
+
+/**
+ * Create Telugu char pairs that might occur.
+ * In theory it's possible to create failing cases by combining certain
+ * single chars, but from what I understand - although I think it's a flaw -
+ * that's not something that would happen in written Telugu.
+ * @return {string[]} Telugu char pairs.
+ */
+export function createTeluguCharPairs() {
+	const sampleCharsOneCodePoint = [...independentVowels, ...consonants, ...rareConsonants, ...numerals];
+	const sampleCharsTwoCodePoints = [...doubleCombos];
+
+	const charPairs = [];
+	for (const char1 of sampleCharsOneCodePoint) {
+		for (const char2 of sampleCharsOneCodePoint) {
+			charPairs.push(`${char1}${char2}`);
+		}
+
+		for (const char2 of sampleCharsTwoCodePoints) {
+			charPairs.push(`${char1}${char2}`);
+		}
+	}
+
+	return charPairs;
 }

--- a/fixture/all-telugu-chars.js
+++ b/fixture/all-telugu-chars.js
@@ -42,20 +42,21 @@ for (const consonant of rareConsonants) {
 }
 
 /**
- * Create all single Telugu chars possible.
- * @return {string[]} All single Telugu chars possible.
- */
+Create all single Telugu characters possible.
+
+@return {string[]} All single Telugu chars possible.
+*/
 export function createAllTeluguChars() {
 	return [...independentVowels, ...consonants, ...rareConsonants, ...numerals, ...doubleCombos, ...tripleCombos];
 }
 
 /**
- * Create Telugu char pairs that might occur.
- * In theory it's possible to create failing cases by combining certain
- * single chars, but from what I understand - although I think it's a flaw -
- * that's not something that would happen in written Telugu.
- * @return {string[]} Telugu char pairs.
- */
+Create Telugu character pairs that might occur.
+
+Although it's possible in theory to create missed cases by combining certain single characters, they are hopefully not something that would happen in written Telugu.
+
+@return {string[]} Telugu char pairs.
+*/
 export function createTeluguCharPairs() {
 	const sampleCharsOneCodePoint = [...independentVowels, ...consonants, ...rareConsonants, ...numerals];
 	const sampleCharsTwoCodePoints = [...doubleCombos];

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ export default function charRegex() {
 	const teluguModifiers = '\\u0c01-\\u0c03\\u0c4d\\u0c55\\u0c56';
 	const teluguNumerals = '\\u0c66-\\u0c6f\\u0c78-\\u0c7e';
 	const teluguSingle = `[${teluguVowels}(?:${teluguConsonants}(?!\\u0c4d))${teluguNumerals}${teluguConsonantsRare}]`;
-	const teluguDouble = `[${teluguConsonants}${teluguConsonantsRare}][${teluguVowelsDiacritic}]|[${teluguConsonants}${teluguConsonantsRare}][${teluguModifiers}`;
+	const teluguDouble = `[${teluguConsonants}${teluguConsonantsRare}][${teluguVowelsDiacritic}]|[${teluguConsonants}${teluguConsonantsRare}][${teluguModifiers}]`;
 	const teluguTriple = `[${teluguConsonants}]\\u0c4d[${teluguConsonants}]`;
 	const telugu = `(?:${teluguTriple}|${teluguDouble}|${teluguSingle})`;
 

--- a/test.js
+++ b/test.js
@@ -1,10 +1,11 @@
 import test from 'ava';
 import createAllChars from 'all-chars';
-import createAllTeluguChars from './fixture/all-telugu-chars.js';
+import {createAllTeluguChars, createTeluguCharPairs} from './fixture/all-telugu-chars.js';
 import createCharRegex from './index.js';
 
 const allChars = createAllChars();
 const allTeluguChars = createAllTeluguChars();
+const sampleTeluguCharPairs = createTeluguCharPairs();
 const charRegex = createCharRegex();
 
 function getCodePoints(string) {
@@ -28,6 +29,13 @@ test('The Pile of Poo Test™', t => {
 for (const character of allTeluguChars) {
 	test(`Test Telugu "${character}" (${getCodePoints(character)})`, t => {
 		t.deepEqual(character.match(charRegex), [character]);
+	});
+}
+
+// Test for Telugu language generating certain char pairs
+for (const characters of sampleTeluguCharPairs) {
+	test(`Test Telugu char pairs "${characters}" (${getCodePoints(characters)})`, t => {
+		t.true(characters.match(charRegex).length === 2);
 	});
 }
 


### PR DESCRIPTION
When merged in, will fix a bug in the Telugu regular expression that may interpret two consecutive Telugu consonants as one single character although they should be counted as two.

The bug was a missing closing square bracket in the regular expression that did not interfere with identifying all single Telugu characters as such and thus slipped the test.